### PR TITLE
chore: skip APIScan

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true
+    "source.organizeImports": "explicit"
   },
 
   "nodejs-testing.extensions": [

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -39,4 +39,7 @@ extends:
 
         testPlatforms: []
 
+        # Build container does not run on Windows
+        skipAPIScan: true
+
         publishPackage: ${{ parameters.publishPackage }}


### PR DESCRIPTION
Verification build https://dev.azure.com/monacotools/Monaco/_build/results?buildId=259851&view=results
There's no APIScan stage so it's good to go.